### PR TITLE
Restructure expenses and rename train to public

### DIFF
--- a/src/app/expenses/expense.config.ts
+++ b/src/app/expenses/expense.config.ts
@@ -1,9 +1,4 @@
-import {
-  Absence,
-  DiscountCard,
-  ExpenseType,
-  Meal
-} from 'src/domain/expense.model';
+import { Absence, Discount, ExpenseType, Meal } from 'src/domain/expense.model';
 import { MeetingType } from 'src/domain/meeting.model';
 
 export type ExpenseConfig = Record<
@@ -12,7 +7,7 @@ export type ExpenseConfig = Record<
     allowed: ExpenseType[];
     transport?: {
       car: number[];
-      train: Record<DiscountCard, number>;
+      public: Record<Discount, number>;
       plan: number;
       bike: number;
     };
@@ -29,7 +24,7 @@ export const expenseConfig: ExpenseConfig = {
     allowed: ['transport'],
     transport: {
       car: [0.05, 0.1, 0.15, 0.2, 0.25, 0.3],
-      train: {
+      public: {
         none: 1,
         BC25: 1.05,
         BC50: 1.1
@@ -43,7 +38,7 @@ export const expenseConfig: ExpenseConfig = {
     allowed: ['transport'],
     transport: {
       car: [0.05, 0.1, 0.15, 0.2, 0.25, 0.3],
-      train: {
+      public: {
         none: 1,
         BC25: 1.05,
         BC50: 1.1
@@ -56,8 +51,8 @@ export const expenseConfig: ExpenseConfig = {
     allowed: ['transport', 'food', 'material'],
     transport: {
       car: [0.2, 0.27, 0.3],
-      train: {
-        // for committee reimbursement, the discount card is not handled by the form
+      public: {
+        // for committee reimbursement, the discount is not handled by the form
         none: 1,
         BC25: 1,
         BC50: 1

--- a/src/app/expenses/food-expense-modal/food-expense-modal.component.html
+++ b/src/app/expenses/food-expense-modal/food-expense-modal.component.html
@@ -59,7 +59,7 @@
 
   <div class="form-group">
     <label for="meals">Mahlzeiten</label>
-    <fieldset id="meals" [formGroup]="meals">
+    <fieldset id="meals">
       <div class="checkbox">
         <input type="checkbox" id="breakfast" formControlName="breakfast" />
         <label for="breakfast">Frühstück</label>

--- a/src/app/expenses/food-expense-modal/food-expense-modal.component.ts
+++ b/src/app/expenses/food-expense-modal/food-expense-modal.component.ts
@@ -55,10 +55,6 @@ export class FoodExpenseModalComponent {
     return this.form.controls.absence;
   }
 
-  get meals() {
-    return this.form.controls.meals;
-  }
-
   get meetingTime() {
     return this.controlService.meetingStep.controls.time.getRawValue();
   }

--- a/src/app/expenses/shared/expense-control.service.ts
+++ b/src/app/expenses/shared/expense-control.service.ts
@@ -4,8 +4,8 @@ import {
   TransportExpense,
   FoodExpense,
   MaterialExpense,
-  CarType,
-  DiscountCard,
+  EngineType,
+  Discount,
   TransportMode,
   Meal,
   Absence
@@ -46,13 +46,13 @@ export class ExpenseControlService {
       origin: ['', Validators.required],
       destination: ['', Validators.required],
       distance: [0, [Validators.required, Validators.min(0)]],
-      car: this.formBuilder.group({
-        type: ['combustion' as CarType, Validators.required],
+      carTrip: this.formBuilder.group({
+        engineType: ['combustion' as EngineType, Validators.required],
         passengers: this.formBuilder.array<string>([])
       }),
-      train: this.formBuilder.group({
+      ticket: this.formBuilder.group({
         price: [0, [Validators.required, Validators.min(0)]],
-        discountCard: ['none' as DiscountCard, Validators.required]
+        discount: ['none' as Discount, Validators.required]
       })
     }) as FormGroup<TransportExpenseForm>;
 
@@ -66,11 +66,9 @@ export class ExpenseControlService {
     return this.formBuilder.group({
       date: new FormControl<Date | null>(null, Validators.required),
       absence: ['workDay' as Absence, [Validators.required, Validators.min(0)]],
-      meals: this.formBuilder.group({
-        breakfast: false as boolean,
-        lunch: false as boolean,
-        dinner: false as boolean
-      })
+      breakfast: false as boolean,
+      lunch: false as boolean,
+      dinner: false as boolean
     });
   }
 
@@ -104,17 +102,21 @@ export class ExpenseControlService {
           origin: value.origin,
           destination: value.destination,
           distance: value.distance!,
-          carType: value.car!.type,
-          passengers: value.car!.passengers
+          carTrip: {
+            engineType: value.carTrip!.engineType,
+            passengers: value.carTrip!.passengers
+          }
         };
-      case 'train':
+      case 'public':
         return {
           type: 'transport',
-          mode: 'train',
+          mode: 'public',
           origin: value.origin,
           destination: value.destination,
-          price: value.train!.price,
-          discountCard: value.train!.discountCard
+          ticket: {
+            price: value.ticket!.price,
+            discount: value.ticket!.discount
+          }
         };
       case 'plan':
         return {
@@ -137,18 +139,10 @@ export class ExpenseControlService {
   }
 
   getFoodExpense(value: RawFormValue<FoodExpenseForm>): FoodExpense {
-    let meals: Meal[] = [];
-    for (let entry of Object.entries(value.meals)) {
-      if (entry[1] === true) {
-        meals.push(entry[0] as Meal);
-      }
-    }
-
     return {
       type: 'food',
-      date: value.date || new Date(),
-      absence: value.absence,
-      meals: meals
+      ...value,
+      date: value.date || new Date()
     };
   }
 
@@ -168,20 +162,20 @@ export class ExpenseControlService {
   ) {
     switch (value) {
       case 'car':
-        form.removeControl('train');
+        form.removeControl('ticket');
         break;
-      case 'train':
+      case 'public':
         form.removeControl('distance');
-        form.removeControl('car');
+        form.removeControl('carTrip');
         break;
       case 'plan':
         form.removeControl('distance');
-        form.removeControl('car');
-        form.removeControl('train');
+        form.removeControl('carTrip');
+        form.removeControl('ticket');
         break;
       case 'bike':
-        form.removeControl('car');
-        form.removeControl('train');
+        form.removeControl('carTrip');
+        form.removeControl('ticket');
         break;
     }
   }

--- a/src/app/expenses/shared/expense-data.pipe.ts
+++ b/src/app/expenses/shared/expense-data.pipe.ts
@@ -1,4 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { FoodExpense } from 'src/domain/expense.model';
 
 export function formatAbsence(value: string): string | null {
   switch (value) {
@@ -13,24 +14,11 @@ export function formatAbsence(value: string): string | null {
   }
 }
 
-export function formatMeal(value: string): string | null {
-  switch (value) {
-    case 'breakfast':
-      return 'Frühstück';
-    case 'lunch':
-      return 'Mittag';
-    case 'dinner':
-      return 'Abend';
-    default:
-      return null;
-  }
-}
-
 @Pipe({
-  name: 'discountCard',
+  name: 'discount',
   standalone: true
 })
-export class DiscountCardPipe implements PipeTransform {
+export class DiscountPipe implements PipeTransform {
   transform(value: string): string | null {
     switch (value) {
       case 'none':
@@ -46,10 +34,10 @@ export class DiscountCardPipe implements PipeTransform {
 }
 
 @Pipe({
-  name: 'carType',
+  name: 'engineType',
   standalone: true
 })
-export class CarTypePipe implements PipeTransform {
+export class EngineTypePipe implements PipeTransform {
   transform(value: string): string | null {
     switch (value) {
       case 'combustion':
@@ -79,14 +67,11 @@ export class AbsencePipe implements PipeTransform {
   standalone: true
 })
 export class MealsPipe implements PipeTransform {
-  transform(value: string): string | null;
-  transform(value: string[]): (string | null)[];
-
-  transform(value: string | string[]) {
-    if (typeof value === 'string') {
-      return formatMeal(value);
-    } else {
-      return value.map(meal => formatMeal(meal));
-    }
+  transform(value: FoodExpense): (string | null)[] {
+    return [
+      ...(value.breakfast ? ['Frühstück'] : []),
+      ...(value.lunch ? ['Mittag'] : []),
+      ...(value.dinner ? ['Abend'] : [])
+    ];
   }
 }

--- a/src/app/expenses/shared/expense-details/expense-details.component.html
+++ b/src/app/expenses/shared/expense-details/expense-details.component.html
@@ -4,18 +4,18 @@
     @switch (exp.mode) {
       @case ('car') {
         {{ exp.distance | number: '1.0-0' }} km,
-        {{ exp.carType | carType }}
-        @if (exp.passengers.length > 0) {
-          &ndash; {{ exp.passengers.length }} Mitfahrer*innen:
-          {{ exp.passengers | join }}
+        {{ exp.carTrip.engineType | engineType }}
+        @if (exp.carTrip.passengers.length > 0) {
+          &ndash; {{ exp.carTrip.passengers.length }} Mitfahrer*innen:
+          {{ exp.carTrip.passengers | join }}
         }
       }
 
-      @case ('train') {
-        @if (exp.discountCard !== 'none') {
-          {{ exp.price | currency }} mit
+      @case ('public') {
+        @if (exp.ticket.discount !== 'none') {
+          {{ exp.ticket.price | currency }} mit
         }
-        {{ exp.discountCard | discountCard }}
+        {{ exp.ticket.discount | discount }}
       }
 
       @case ('plan') {
@@ -29,8 +29,8 @@
   }
 
   @case ('food') {
-    @if (exp.meals.length > 0) {
-      Abzüglich {{ exp.meals | meals | join }}
+    @if (exp.breakfast || exp.lunch || exp.dinner) {
+      Abzüglich {{ exp | meals | join }}
     } @else {
       Ohne Abzüge
     }

--- a/src/app/expenses/shared/expense-details/expense-details.component.ts
+++ b/src/app/expenses/shared/expense-details/expense-details.component.ts
@@ -1,8 +1,8 @@
 import { CurrencyPipe, DecimalPipe } from '@angular/common';
 import { Component, input } from '@angular/core';
 import {
-  CarTypePipe,
-  DiscountCardPipe,
+  EngineTypePipe,
+  DiscountPipe,
   MealsPipe
 } from 'src/app/expenses/shared/expense-data.pipe';
 import { JoinPipe } from 'src/app/shared/join.pipe';
@@ -15,8 +15,8 @@ import { Expense } from 'src/domain/expense.model';
   imports: [
     DecimalPipe,
     CurrencyPipe,
-    DiscountCardPipe,
-    CarTypePipe,
+    DiscountPipe,
+    EngineTypePipe,
     JoinPipe,
     MealsPipe
   ]

--- a/src/app/expenses/shared/expense-form.ts
+++ b/src/app/expenses/shared/expense-form.ts
@@ -1,8 +1,8 @@
 import { FormArray, FormControl, FormGroup } from '@angular/forms';
 import {
   Absence,
-  CarType,
-  DiscountCard,
+  EngineType,
+  Discount,
   TransportMode
 } from 'src/domain/expense.model';
 
@@ -11,27 +11,23 @@ export type TransportExpenseForm = {
   origin: FormControl<string>;
   destination: FormControl<string>;
   distance?: FormControl<number>;
-  car?: FormGroup<CarForm>;
-  train?: FormGroup<TrainForm>;
+  carTrip?: FormGroup<CarTripForm>;
+  ticket?: FormGroup<TicketForm>;
 };
 
-export type TrainForm = {
+export type TicketForm = {
   price: FormControl<number>;
-  discountCard: FormControl<DiscountCard>;
+  discount: FormControl<Discount>;
 };
 
-export type CarForm = {
-  type: FormControl<CarType>;
+export type CarTripForm = {
+  engineType: FormControl<EngineType>;
   passengers: FormArray<FormControl<string>>;
 };
 
 export type FoodExpenseForm = {
   date: FormControl<Date | null>;
   absence: FormControl<Absence>;
-  meals: FormGroup<MealForm>;
-};
-
-export type MealForm = {
   breakfast: FormControl<boolean>;
   lunch: FormControl<boolean>;
   dinner: FormControl<boolean>;

--- a/src/app/expenses/shared/expense.service.ts
+++ b/src/app/expenses/shared/expense.service.ts
@@ -21,15 +21,15 @@ export class ExpenseService {
 
         switch (expense.mode) {
           case 'car':
-            const nPax = expense.passengers.length;
+            const nPax = expense.carTrip.passengers.length;
             const maxPax = this.config.transport.car.length - 1;
             const index = nPax < maxPax ? nPax : maxPax;
-            const carFactor = this.config.transport.car[index];
-            return expense.distance * carFactor;
-          case 'train':
-            const trainFactor =
-              this.config.transport.train[expense.discountCard];
-            return expense.price * trainFactor;
+            const distanceFactor = this.config.transport.car[index];
+            return expense.distance * distanceFactor;
+          case 'public':
+            const discountFactor =
+              this.config.transport.public[expense.ticket.discount];
+            return expense.ticket.price * discountFactor;
           case 'bike':
             const bikeFactor = this.config.transport.bike;
             return expense.distance * bikeFactor;
@@ -42,9 +42,9 @@ export class ExpenseService {
         }
 
         let amount = this.config.food.allowance[expense.absence];
-        for (let meal of expense.meals) {
-          amount -= this.config.food.meals[meal];
-        }
+        amount -= expense.breakfast ? this.config.food.meals.breakfast : 0;
+        amount -= expense.lunch ? this.config.food.meals.lunch : 0;
+        amount -= expense.dinner ? this.config.food.meals.dinner : 0;
 
         return amount > 0 ? amount : 0;
       case 'material':

--- a/src/app/expenses/shared/transport-mode.pipe.ts
+++ b/src/app/expenses/shared/transport-mode.pipe.ts
@@ -5,8 +5,8 @@ export function formatTransportMode(value: TransportMode) {
   switch (value) {
     case 'car':
       return 'Autofahrt';
-    case 'train':
-      return 'Zugfahrt';
+    case 'public':
+      return 'Fahrt mit ÖPNV';
     case 'plan':
       return 'Fahrt mit ÖPNV-Abo';
     case 'bike':

--- a/src/app/expenses/transport-expense-modal/transport-expense-modal.component.html
+++ b/src/app/expenses/transport-expense-modal/transport-expense-modal.component.html
@@ -67,9 +67,9 @@
       </div>
     }
 
-    <!-- train expenses -->
-    @if (train) {
-      <fieldset [formGroup]="train">
+    <!-- public expenses -->
+    @if (ticket) {
+      <fieldset [formGroup]="ticket">
         <div class="form-group">
           <label for="price">Ticketpreis (ermäßigt)</label>
           <input
@@ -80,21 +80,21 @@
             required
           />
           @if (
-            train.controls.price.hasError('required') &&
-            train.controls.price.touched
+            ticket.controls.price.hasError('required') &&
+            ticket.controls.price.touched
           ) {
             <div class="error-message">Bitte gib einen Preis ein.</div>
           }
-          @if (train.controls.price.hasError('min')) {
+          @if (ticket.controls.price.hasError('min')) {
             <div class="error-message">Bitte gib einen gültigen Preis ein.</div>
           }
         </div>
 
         <div class="form-group">
-          <label for="discountCard">BahnCard</label>
+          <label for="discount">BahnCard</label>
           <select
-            id="discountCard"
-            formControlName="discountCard"
+            id="discount"
+            formControlName="discount"
             class="form-control"
             required
           >
@@ -103,8 +103,8 @@
             <option value="BC50">BahnCard 50</option>
           </select>
           @if (
-            train.controls.discountCard.hasError('required') &&
-            train.controls.discountCard.touched
+            ticket.controls.discount.hasError('required') &&
+            ticket.controls.discount.touched
           ) {
             <div class="error-message">Bitte wähle deine BahnCard aus.</div>
           }
@@ -113,13 +113,13 @@
     }
 
     <!-- car expenses -->
-    @if (car) {
-      <fieldset [formGroup]="car">
+    @if (carTrip) {
+      <fieldset [formGroup]="carTrip">
         <div class="form-group">
-          <label for="carType">Auto Typ</label>
+          <label for="engineType">Auto Typ</label>
           <select
-            id="carType"
-            formControlName="type"
+            id="engineType"
+            formControlName="engineType"
             class="form-control"
             required
           >
@@ -128,7 +128,8 @@
             <option value="electric">Elektro</option>
           </select>
           @if (
-            car.controls.type.hasError('required') && car.controls.type.touched
+            carTrip.controls.engineType.hasError('required') &&
+            carTrip.controls.engineType.touched
           ) {
             <div class="error-message">
               Bitte wähle den Typ deines Autos aus.
@@ -144,7 +145,7 @@
             als einzelne Auslage an.
           </p>
           @for (
-            passenger of car.controls.passengers.controls;
+            passenger of carTrip.controls.passengers.controls;
             track passenger
           ) {
             <div class="passengers-item" formArrayName="passengers">

--- a/src/app/expenses/transport-expense-modal/transport-expense-modal.component.ts
+++ b/src/app/expenses/transport-expense-modal/transport-expense-modal.component.ts
@@ -63,19 +63,19 @@ export class TransportExpenseModalComponent {
     return this.form.controls.distance;
   }
 
-  get train() {
-    return this.form.controls.train;
+  get ticket() {
+    return this.form.controls.ticket;
   }
 
-  get car() {
-    return this.form.controls.car;
+  get carTrip() {
+    return this.form.controls.carTrip;
   }
 
   getIcon(mode: TransportMode) {
     switch (mode) {
       case 'car':
         return '&#xe531;';
-      case 'train':
+      case 'public':
         return '&#xe570;';
       case 'plan':
         return '&#xe8f8;';
@@ -94,12 +94,12 @@ export class TransportExpenseModalComponent {
       validators: Validators.required
     });
 
-    const passengers = this.car?.controls.passengers;
+    const passengers = this.carTrip?.controls.passengers;
     passengers?.push(control);
   }
 
   removePassenger(index: number) {
-    const passengers = this.car?.controls.passengers;
+    const passengers = this.carTrip?.controls.passengers;
     passengers?.removeAt(index);
   }
 

--- a/src/app/info/expense-rates/expense-rates.component.html
+++ b/src/app/info/expense-rates/expense-rates.component.html
@@ -52,22 +52,22 @@
     }
   </table>
 
-  <h3>Zugfahrt</h3>
+  <h3>Fahrt mit ÖPNV</h3>
 
   <p class="explanation">
-    Die Erstattung von Zugfahrten erfolgt abhängig vom (ermäßigten) Ticketpreis
-    und der genutzten BahnCard.
+    Die Erstattung von Fahrten mit dem ÖPNV erfolgt abhängig vom (ermäßigten)
+    Ticketpreis und der genutzten BahnCard.
   </p>
   <p class="important">Bitte eine Kopie der Fahrkarte anhängen!</p>
 
   @if (meetingType !== 'committee') {
     <table>
       @for (
-        entry of config.transport.train | keyvalue: originalOrder;
+        entry of config.transport.public | keyvalue: originalOrder;
         track entry.key
       ) {
         <tr>
-          <td>{{ entry.key | discountCard }}</td>
+          <td>{{ entry.key | discount }}</td>
           <td>{{ entry.value | percent }} des Ticketpreis</td>
         </tr>
       }
@@ -82,7 +82,7 @@
     </p>
   }
 
-  <h3>Fahrt mit Aboticket</h3>
+  <h3>Fahrt mit ÖPNV-Abo</h3>
 
   <p class="explanation">
     Für die Nutzung von Abotickets (Deutschlandticket, Semesterticket, o.ä.)
@@ -128,15 +128,18 @@
     Bei Gewährung unentgeltlicher Verpflegung werden folgende Beträge abgezogen:
   </p>
   <table>
-    @for (
-      entry of config.food.meals | keyvalue: originalOrder;
-      track entry.key
-    ) {
-      <tr>
-        <td>{{ entry.key | meals }}</td>
-        <td>{{ entry.value | currency }}</td>
-      </tr>
-    }
+    <tr>
+      <td>Frühstück</td>
+      <td>{{ config.food.meals.breakfast | currency }}</td>
+    </tr>
+    <tr>
+      <td>Mittag</td>
+      <td>{{ config.food.meals.lunch | currency }}</td>
+    </tr>
+    <tr>
+      <td>Abend</td>
+      <td>{{ config.food.meals.dinner | currency }}</td>
+    </tr>
   </table>
 
   <p class="explanation">

--- a/src/app/info/expense-rates/expense-rates.component.ts
+++ b/src/app/info/expense-rates/expense-rates.component.ts
@@ -4,8 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { expenseConfig } from 'src/app/expenses/expense.config';
 import {
   AbsencePipe,
-  DiscountCardPipe,
-  MealsPipe
+  DiscountPipe
 } from 'src/app/expenses/shared/expense-data.pipe';
 import { MeetingType } from 'src/domain/meeting.model';
 
@@ -13,14 +12,7 @@ import { MeetingType } from 'src/domain/meeting.model';
   selector: 'app-expense-rates',
   templateUrl: './expense-rates.component.html',
   styleUrls: ['./expense-rates.component.css'],
-  imports: [
-    CurrencyPipe,
-    KeyValuePipe,
-    PercentPipe,
-    DiscountCardPipe,
-    AbsencePipe,
-    MealsPipe
-  ]
+  imports: [CurrencyPipe, KeyValuePipe, PercentPipe, DiscountPipe, AbsencePipe]
 })
 export class ExpenseRatesComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);

--- a/src/app/reimbursement/expenses-step/expenses-step.component.ts
+++ b/src/app/reimbursement/expenses-step/expenses-step.component.ts
@@ -80,7 +80,7 @@ export class ExpensesStepComponent {
   }
 
   getAllowedModes(direction: Direction) {
-    let allowedModes: TransportMode[] = ['car', 'train'];
+    let allowedModes: TransportMode[] = ['car', 'public'];
 
     if (direction !== 'onsite') {
       allowedModes.push('bike');

--- a/src/app/reimbursement/overview-step/overview-step.component.html
+++ b/src/app/reimbursement/overview-step/overview-step.component.html
@@ -58,9 +58,7 @@
 
   @if (report.receiptsRequired) {
     <h2>Belege</h2>
-    <p>
-      Bitte denke daran, dass wir die Belege für deine Zugtickets benötigen.
-    </p>
+    <p>Bitte denke daran, dass wir die Belege für deine Tickets benötigen.</p>
     @if (reimbursement.meeting.type === 'committee') {
       <p>
         Falls du eine BahnCard benutzt hast, hänge bitte die Rechnung für diese

--- a/src/app/reimbursement/shared/reimbursement-control.service.ts
+++ b/src/app/reimbursement/shared/reimbursement-control.service.ts
@@ -103,7 +103,7 @@ export class ReimbursementControlService {
               ),
               onsite: this.formBuilder.array<FormGroup<TransportExpenseForm>>(
                 [],
-                allowedTransportModes(['car', 'train'])
+                allowedTransportModes(['car', 'public'])
               ),
               outbound: this.formBuilder.array<FormGroup<TransportExpenseForm>>(
                 [],
@@ -286,23 +286,23 @@ export class ReimbursementControlService {
     const origin = this.completeOrigin(direction);
     form.controls.origin.setValue(origin);
 
-    // auto-complete car type
-    const car = form.controls.car;
-    if (car) {
+    // auto-complete engine type
+    const carTrip = form.controls.carTrip;
+    if (carTrip) {
       for (let expense of expenses) {
-        if (expense.car) {
-          car.controls.type.setValue(expense.car.type);
+        if (expense.carTrip) {
+          carTrip.controls.engineType.setValue(expense.carTrip.engineType);
           break;
         }
       }
     }
 
-    // auto-complete discount card
-    const train = form.controls.train;
-    if (train) {
+    // auto-complete discount
+    const ticket = form.controls.ticket;
+    if (ticket) {
       for (let expense of expenses) {
-        if (expense.train) {
-          train.controls.discountCard.setValue(expense.train.discountCard);
+        if (expense.ticket) {
+          ticket.controls.discount.setValue(expense.ticket.discount);
           break;
         }
       }

--- a/src/app/reimbursement/shared/reimbursement.service.ts
+++ b/src/app/reimbursement/shared/reimbursement.service.ts
@@ -82,11 +82,11 @@ export class ReimbursementService {
     }
 
     // check if receipt is required
-    const trainExpense = this.getExpenses('transport', reimbursement).some(e =>
-      ['train', 'plan'].includes(e.mode)
+    const publicExpense = this.getExpenses('transport', reimbursement).some(e =>
+      ['public', 'plan'].includes(e.mode)
     );
     const materialExpenses = (categories.material || 0) > 0;
-    const receiptsRequired = trainExpense || materialExpenses;
+    const receiptsRequired = publicExpense || materialExpenses;
 
     return { categories, total, totalReduced, receiptsRequired };
   }

--- a/src/domain/expense.model.ts
+++ b/src/domain/expense.model.ts
@@ -1,6 +1,6 @@
 export type Direction = 'inbound' | 'onsite' | 'outbound';
-export type DiscountCard = 'BC25' | 'BC50' | 'none';
-export type CarType = 'combustion' | 'electric' | 'plug-in-hybrid';
+export type Discount = 'BC25' | 'BC50' | 'none';
+export type EngineType = 'combustion' | 'electric' | 'plug-in-hybrid';
 export type Absence = 'fullDay' | 'travelDay' | 'workDay';
 export type Meal = 'breakfast' | 'lunch' | 'dinner';
 
@@ -19,14 +19,18 @@ export interface BikeExpense extends TransportExpenseBase {
 export interface CarExpense extends TransportExpenseBase {
   mode: 'car';
   distance: number;
-  carType: CarType;
-  passengers: string[];
+  carTrip: {
+    engineType: EngineType;
+    passengers: string[];
+  };
 }
 
-export interface TrainExpense extends TransportExpenseBase {
-  mode: 'train';
-  discountCard: DiscountCard;
-  price: number;
+export interface PublicTransportExpense extends TransportExpenseBase {
+  mode: 'public';
+  ticket: {
+    discount: Discount;
+    price: number;
+  };
 }
 
 export interface PublicTransportPlanExpense extends TransportExpenseBase {
@@ -37,7 +41,9 @@ export interface FoodExpense {
   type: 'food';
   date: Date;
   absence: Absence;
-  meals: Meal[];
+  breakfast: boolean;
+  lunch: boolean;
+  dinner: boolean;
 }
 
 export interface MaterialExpense {
@@ -50,7 +56,7 @@ export interface MaterialExpense {
 export type TransportExpense =
   | BikeExpense
   | CarExpense
-  | TrainExpense
+  | PublicTransportExpense
   | PublicTransportPlanExpense;
 export type TransportMode = TransportExpense['mode'];
 


### PR DESCRIPTION
* Zugfahrten umbenannt, damit klar ist, dass auch Busfahrten oder ähnliches hier abgerechnet werden können
* Angleichen der Expense-Objekte an die Struktur der Formulare und Umbenennung einiger Felder für mehr Klarheit
* Entfernung der Untergruppe für Mahlzeiten bei Verpflegungspauschalen

Dadurch werden die Datenstrukturen im Frontend auch für das geplante Backend vorbereitet.